### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         //noinspection GradleDependency
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.4'
         classpath 'com.huawei.agconnect:agcp:1.3.1.300'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
线上Demo hms:awareness sdk(3.1.0.300)已是最新版本，Android Gradle插件 未更新至3.5.4或更高版本，导致打包报错，请修改！